### PR TITLE
Added ability to keep orginal value type in custom validation methods

### DIFF
--- a/lib/mongoose-validator.js
+++ b/lib/mongoose-validator.js
@@ -16,6 +16,7 @@ Validator.validate = function(options, method) {
       , _method    = hasOptions ? method : options
       , msg        = options.message ? options.message : (customError[_method] || defaultError[_method])
       , passIfEmpty = options.passIfEmpty ? options.passIfEmpty : false
+      , keepOriginalValue = options.keepOriginalValue ? true: false
       , args       = Array.prototype.slice.call(arguments, (hasOptions ? 2 : 1));
 
     if (Validator[_method]) {
@@ -24,7 +25,10 @@ Validator.validate = function(options, method) {
                 if (passIfEmpty && (val === '' || val == null)) {
                     return next(true);
                 }
-                next(Validator.check(val)[_method].apply(Validator, args));
+                if (keepOriginalValue) {
+                    return next(Validator.checkWithOptions(val, {keepOriginalValue:true})[_method].apply(Validator, args));
+                }
+                return next(Validator.check(val)[_method].apply(Validator, args));
             },
             msg: msg
         }
@@ -36,6 +40,18 @@ Validator.validate = function(options, method) {
 Validator.extend = function (name, fn, msg) {
     customError[name] = msg || "Error";
     Object.getPrototypeOf(Validator)[name] = fn;
+}
+
+Validator.checkWithOptions = function(str, options) {
+    options || (options = {})
+    if (options.keepOriginalValue)
+        this.str = str;
+    else
+        this.str = typeof( str ) === 'undefined' || str === null || (isNaN(str) && str.length === undefined) ? '' : str+'';
+
+    this.msg = options.fail_msg;
+    this._errors = this._errors || [];
+    return this;
 }
 
 module.exports = Validator;


### PR DESCRIPTION
When trying to use a custom validation method on a non-string type,
validator would try to force the type to a string, which made
validation checking on non-string types very difficult. This PR adds
the ability to pass an option called: "keepOriginalValue: true" (just
like passIfEmpty) and this will not force "this.str" inside custom
validation functions to a string, but leave it untouched. Leaving it
untouched allows for custom type checking as well as still being able
to chain it with other mongoose-validators. Tests included and passing.
