### PR TITLE
updating to validator v3.18.x with isFQDN support

### DIFF
--- a/lib/default-errors.js
+++ b/lib/default-errors.js
@@ -4,6 +4,7 @@ module.exports = {
   matches: 'Does not match',
   isEmail: 'Invalid email',
   isUrl: 'Invalid URL',
+  isFQDN: 'Invalid FQDN',
   isIP: 'Invalid IP',
   isAlpha: 'Invalid characters',
   isNumeric: 'Invalid number',

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     }
   ],
   "dependencies": {
-    "validator": "3.x.x"
+    "validator": "3.18.x"
   },
   "devDependencies": {
     "mongoose": "3.8.x",


### PR DESCRIPTION
I added `isFQDN` validator. Please accept this PR to enable new features of `validator.js` `v3.18.0`. Thx.
