### PR TITLE
Allow use of arguments as part of custom error message.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ var nameValidator = [
   validate({
     validator: 'isLength',
     arguments: [3, 50],
-    message: 'Name should be between 3 and 50 characters'
+    message: 'Name should be between {args.0} and {args.1} characters'
   }),
   validate({
     validator: 'isAlphanumeric',
@@ -64,7 +64,7 @@ Arguments to be passed to the validator. These can either be an array of argumen
 Some of the validator.js validators require a value to check against (isEmail, isUrl etc). There may be instances where you don't have a value to check i.e. a path that is not required and as such these few validators return an false value causing validation to fail. This can now be bypassed by setting the `passIfEmpty` option.
 
 ### option.message - optional
-Set the error message to be used should the validator fail. If no error message is set then mongoose-validator will attempt to use one of the built-in default messages, if it can't then a simple message of 'Error' will be returned.
+Set the error message to be used should the validator fail. If no error message is set then mongoose-validator will attempt to use one of the built-in default messages, if it can't then a simple message of 'Error' will be returned. You can pass `{{args.indexPosition}}` for replacing chunks of message by argument's value. Use `{args.0}` if your arguments isn't an array.
 
 ## Regular Expressions
 

--- a/lib/mongoose-validator.js
+++ b/lib/mongoose-validator.js
@@ -37,6 +37,7 @@ var validate = function(options) {
   var validator    = (name instanceof Function) ? name : validatorjs[name];
 
   args = !Array.isArray(args) ? [args] : args;
+  message = message.replace(/{{args\.(\d+)}}/g, function(replace, argIndex) {return args[argIndex]});
 
   if (validator) {
     return {

--- a/lib/mongoose-validator.js
+++ b/lib/mongoose-validator.js
@@ -37,7 +37,7 @@ var validate = function(options) {
   var validator    = (name instanceof Function) ? name : validatorjs[name];
 
   args = !Array.isArray(args) ? [args] : args;
-  message = message.replace(/{{args\.(\d+)}}/g, function(replace, argIndex) {return args[argIndex]});
+  message = message.replace(/{args\.(\d+)}/g, function(replace, argIndex) {return args[argIndex]});
 
   if (validator) {
     return {

--- a/test/test.js
+++ b/test/test.js
@@ -158,7 +158,7 @@ describe('Mongoose Validator', function() {
   });
 
   it('Should replace args on custom error message', function (done) {
-    schema.path('name').validate(validate({ validator: 'isLength', arguments: [5, 10], message: 'at least {{args.0}} and less than {{args.1}}' }));
+    schema.path('name').validate(validate({ validator: 'isLength', arguments: [5, 10], message: 'at least {args.0} and less than {args.1}' }));
 
     should.exist(doc);
 

--- a/test/test.js
+++ b/test/test.js
@@ -157,6 +157,23 @@ describe('Mongoose Validator', function() {
     });
   });
 
+  it('Should replace args on custom error message', function (done) {
+    schema.path('name').validate(validate({ validator: 'isLength', arguments: [5, 10], message: 'at least {{args.0}} and less than {{args.1}}' }));
+
+    should.exist(doc);
+
+    doc.name = 'Joe';
+
+    doc.save(function(err, person) {
+      should.exist(err);
+      should.not.exist(person);
+      err.should.be.instanceof(Error).and.have.property('name', 'ValidationError');
+      err.errors.name.should.have.property('path', 'name');
+      err.errors.name.message.should.equal('at least 5 and less than 10');
+      return done();
+    });
+  });
+
   it('Should use a custom extend test and pass', function(done) {
     schema.path('name').validate(validate({ validator: 'isType', arguments: 'string'}));
 


### PR DESCRIPTION
When using custom global error message, use of arguments as part of message would be great.

example:
```
validate.defaultErrorMessages.isLength = "{{PATH}} should be between {{args.0}} and {{args.1}} characters";

var nameValidator = [
  validate({
    validator: 'isLength',
    arguments: [5, 40],
  })
];
```
would be replaced by `name should be between 5 and 40 characters`

