### PR TITLE
Bind validator scope to `this`

### DIFF
--- a/lib/mongoose-validator.js
+++ b/lib/mongoose-validator.js
@@ -53,7 +53,7 @@ function validate (options) {
           return next(true);
         }
 
-        return next(validator.apply(null, validatorArgs));
+        return next(validator.apply(this, validatorArgs));
       },
       message: message
     }, extend);


### PR DESCRIPTION
Allows users to access the mongoose validate scope from within a custom validator function.

Example:
```javascript
var mongoose = require("mongoose");
var validate = require("mongoose-validator");

var MySchema = new mongoose.Schema({
  path: {
    type: String,
    validate: [
      validate({
        validator: function (val) {
          if (!this.isModified("path")) {
            return true;
          }
          // ...
        },
        message: "Invalid ..."
      })
    ]
  }
});

```