### PR TITLE
change context for extended validators

### DIFF
--- a/lib/mongoose-validator.js
+++ b/lib/mongoose-validator.js
@@ -73,7 +73,7 @@ function validate (options) {
  */
 validate.extend = function (name, fn, errorMsg) {
   if (!validatorjs[name]) {
-    validatorjs[name]   = function () { return fn.apply(validatorjs, Array.prototype.slice.call(arguments)); };
+    validatorjs[name]   = function () { return fn.apply(this, Array.prototype.slice.call(arguments)); };
     errorMessages[name] = errorMsg || 'Error';
   }
   else {

--- a/test/test.js
+++ b/test/test.js
@@ -29,6 +29,10 @@ extend('isArray', function(val) {
   return Array.isArray(val);
 }, 'Not an array');
 
+extend('isContextEqlModelInstance', function(val) {
+  return this._id && this.name === val;
+}, 'this is not a model instance');
+
 // Tests
 // ------------------------------------------------------------
 describe('Mongoose Validator:', function() {
@@ -425,6 +429,21 @@ describe('Mongoose Validator:', function() {
         should.exist(err);
         should.not.exist(person);
         err.errors.name.message.should.equal('Username should not be empty');
+        return done();
+      });
+    });
+
+    it('Custom validator calls with this = model instance', function(done) {
+
+      schema.path('name').validate(validate({ validator: 'isContextEqlModelInstance' }));
+
+      should.exist(doc);
+
+      doc.name = 'Joe';
+
+      doc.save(function(err, person) {
+        should.not.exist(err);
+        should.exist(person);
         return done();
       });
     });


### PR DESCRIPTION
there is no way to get access to model instance inside extended validator.
opposite to mongoose validation

http://mongoosejs.com/docs/validation.html, 'Update Validators and this' section

> this refers to the document being validated when using document validation. However, when running update validators, the document being updated may not be in the server's memory, so by default the value of this is not defined.

PS: all tests passed
