### PR TITLE
DeprecationWarning: Implicit async custom validators

### DIFF
--- a/lib/mongoose-validator.js
+++ b/lib/mongoose-validator.js
@@ -54,6 +54,7 @@ function validate (options) {
 
         return next(validator.apply(this, validatorArgs));
       },
+      isAsync: true,
       message: message
     }, extend);
   }


### PR DESCRIPTION
When the mongoose-validator is executed by Mongoose (>= 4.9.0)  for the first time, it appears this message on console:
"DeprecationWarning: Implicit async custom validators (custom validators that take 2 arguments) are deprecated in mongoose >= 4.9.0"

I followed the instruction in [Mongoose doc](http://mongoosejs.com/docs/validation.html#async-custom-validators) and this solved.