### PR TITLE
Upgrade validator major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "mongoose-validator",
 	"description": "Validators for mongoose models utilising validator.js",
-	"version": "1.3.2",
+	"version": "1.3.3",
 	"author": {
 		"name": "Lee Powell",
 		"email": "lee@leepowell.co.uk",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	],
 	"dependencies": {
 		"is": "^3.2.1",
-		"validator": "^7.0.0"
+		"validator": "^9.4.0"
 	},
 	"devDependencies": {
 		"jsdoc": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "mongoose-validator",
 	"description": "Validators for mongoose models utilising validator.js",
-	"version": "1.3.3",
+	"version": "1.4.0",
 	"author": {
 		"name": "Lee Powell",
 		"email": "lee@leepowell.co.uk",


### PR DESCRIPTION
Just ensure we're using the latest `validator` package version. 
No breaking changes as far as I know.